### PR TITLE
Provide HTTP client globally as a ZLayer

### DIFF
--- a/src/main/scala/org/renci/cam/HttpClient.scala
+++ b/src/main/scala/org/renci/cam/HttpClient.scala
@@ -1,0 +1,23 @@
+package org.renci.cam
+
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
+import zio._
+import zio.interop.catz._
+
+import scala.concurrent.duration.{Duration, MINUTES}
+
+object HttpClient {
+
+  type HttpClient = Has[Client[Task]]
+
+  def makeHttpClient: UIO[TaskManaged[Client[Task]]] =
+    ZIO.runtime[Any].map { implicit rts =>
+      BlazeClientBuilder[Task](rts.platform.executor.asEC).withConnectTimeout(Duration(3, MINUTES)).resource.toManaged
+    }
+
+  def makeHttpClientLayer: UIO[TaskLayer[HttpClient]] = makeHttpClient.map(ZLayer.fromManaged)
+
+  val client: ZIO[HttpClient, Nothing, Client[Task]] = ZIO.service
+
+}

--- a/src/main/scala/org/renci/cam/Utilities.scala
+++ b/src/main/scala/org/renci/cam/Utilities.scala
@@ -1,21 +1,22 @@
 package org.renci.cam
 
 import io.circe.Json
-import org.http4s.{MediaType, Method, Request}
-import org.http4s.headers.{`Content-Type`, Accept}
-import zio.{Task, ZIO}
-import org.http4s.implicits._
 import org.http4s.circe._
+import org.http4s.headers.Accept
+import org.http4s.implicits._
+import org.http4s.{MediaType, Method, Request}
+import org.renci.cam.HttpClient.HttpClient
+import zio._
 import zio.interop.catz._
 
 object Utilities {
 
-  def getBiolinkPrefixes: ZIO[Any, Throwable, Map[String, String]] =
+  def getBiolinkPrefixes: ZIO[HttpClient, Throwable, Map[String, String]] =
     for {
-      httpClient <- SPARQLQueryExecutor.makeHttpClient
+      httpClient <- HttpClient.client
       uri = uri"https://biolink.github.io/biolink-model/context.jsonld"
       request = Request[Task](Method.GET, uri).withHeaders(Accept(MediaType.application.`ld+json`))
-      biolinkModelJson <- httpClient.use(_.expect[Json](request))
+      biolinkModelJson <- httpClient.expect[Json](request)
       cursor = biolinkModelJson.hcursor
       contextValue <- ZIO.fromEither(cursor.downField("@context").as[Map[String, Json]])
       curies =

--- a/src/test/scala/org/renci/cam/BlazegraphTest.scala
+++ b/src/test/scala/org/renci/cam/BlazegraphTest.scala
@@ -20,7 +20,7 @@ object BlazegraphTest extends DefaultRunnableSpec {
               SELECT DISTINCT ?predicate WHERE { bl:has_participant <http://reasoner.renci.org/vocab/slot_mapping> ?predicate . }"""
 
         for {
-          httpClient <- SPARQLQueryExecutor.makeHttpClient
+          httpClient <- HttpClient.makeHttpClient
           uri =
             uri"http://152.54.9.207:9999/blazegraph/sparql"
               .withQueryParam("query", query)

--- a/src/test/scala/org/renci/cam/PullBiolinkTypeMapTest.scala
+++ b/src/test/scala/org/renci/cam/PullBiolinkTypeMapTest.scala
@@ -23,7 +23,7 @@ object PullBiolinkTypeMapTest extends DefaultRunnableSpec {
     suite("PullBiolinkTypeMapTestSpec")(
       testM("pull") {
         for {
-          httpClient <- SPARQLQueryExecutor.makeHttpClient
+          httpClient <- HttpClient.makeHttpClient
           uri = uri"https://biolink.github.io/biolink-model/context.jsonld"
           request = Request[Task](Method.GET, uri).withHeaders(Accept(MediaType.application.`ld+json`),
                                                                `Content-Type`(MediaType.application.`ld+json`))

--- a/src/test/scala/org/renci/cam/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/QueryServiceTest.scala
@@ -32,7 +32,7 @@ object QueryServiceTest extends DefaultRunnableSpec {
       } @@ ignore,
       testM("test simple query") {
         for {
-          httpClient <- SPARQLQueryExecutor.makeHttpClient
+          httpClient <- HttpClient.makeHttpClient
           encoded = {
             val n0Node = TRAPIQueryNode("n0", Some("gene"), None)
             val n1Node = TRAPIQueryNode("n1", Some("biological_process"), None)
@@ -55,19 +55,19 @@ object QueryServiceTest extends DefaultRunnableSpec {
         } yield assert(response)(isNonEmptyString)
       } @@ ignore,
       testM("test gene to gene") {
-        val n0Node = TRAPIQueryNode("n0", Some("gene"), Some("UniProtKB:P30530") )
+        val n0Node = TRAPIQueryNode("n0", Some("gene"), Some("UniProtKB:P30530"))
         val n1Node = TRAPIQueryNode("n1", Some("biological_process"), None)
         val n2Node = TRAPIQueryNode("n2", Some("biological_process"), None)
         val n3Node = TRAPIQueryNode("n3", Some("gene"), None)
         val e0Edge = TRAPIQueryEdge("e0", "n1", "n0", None)
-        val e1Edge = TRAPIQueryEdge("e1", "n1", "n2", None/*Some("enabled_by")*/)
+        val e1Edge = TRAPIQueryEdge("e1", "n1", "n2", None /*Some("enabled_by")*/ )
         val e2Edge = TRAPIQueryEdge("e2", "n2", "n3", None)
         val queryGraph = TRAPIQueryGraph(List(n0Node, n1Node, n2Node, n3Node), List(e0Edge, e1Edge, e2Edge))
         val message = TRAPIMessage(Some(queryGraph), None, None)
         val requestBody = TRAPIQueryRequestBody(message)
         val encoded = requestBody.asJson.deepDropNullValues.noSpaces
         for {
-          httpClient <- SPARQLQueryExecutor.makeHttpClient
+          httpClient <- HttpClient.makeHttpClient
           uri = uri"http://127.0.0.1:8080/query".withQueryParam("limit", 1) // scala
           //uri = uri"http://127.0.0.1:6434/query".withQueryParam("limit", 1) // python
           request = Request[Task](Method.POST, uri)
@@ -77,7 +77,7 @@ object QueryServiceTest extends DefaultRunnableSpec {
           _ = println("response: " + response)
           _ = Files.write(Paths.get("src/test/resources/local-scala-gene2gene.json"), response.getBytes())
         } yield assert(response)(isNonEmptyString)
-      } @@ ignore,
+      } @@ ignore
     )
 
 }


### PR DESCRIPTION
This moves HTTP client creation into a ZLayer. This way it is constructed once and shut down when the app stops. It's preferred to use one client instance since it maintains a connection pool so connections are reused across requests. Down the road we could possibly hide this behind a SPARQL endpoint service layer; we could have a test implementation that queries local files instead of a Blazegraph server to make the tests repeatable.

See https://zio.dev/docs/howto/howto_use_layers and https://lp.scalac.io/zio-modularity-ebook/