### PR TITLE
adding docker instructions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,6 @@
-enablePlugins(JavaAppPackaging)
+import com.typesafe.sbt.packager.docker._
+
+enablePlugins(JavaAppPackaging, DockerPlugin)
 
 organization := "org.renci"
 
@@ -52,4 +54,14 @@ libraryDependencies ++= {
     "ch.qos.logback"               % "logback-classic"          % logbackVersion,
     "com.typesafe.scala-logging"  %% "scala-logging"            % "3.9.2"
   )
+}
+
+dockerBaseImage := "openjdk:14-alpine"
+daemonUser in Docker := "camkpapi"
+dockerExposedPorts += 8080
+dockerApiVersion := Some(DockerApiVersion(1, 40))
+dockerChmodType := DockerChmodType.UserGroupWriteExecute
+dockerCommands := dockerCommands.value.flatMap {
+  case cmd @ Cmd("EXPOSE", _) => List(Cmd("RUN", "apk update && apk add bash"), cmd)
+  case other => List(other)
 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 {
-  host = localhost
+  host = 0.0.0.0
   port = 8080
   sparql-endpoint = "http://152.54.9.207:9999/blazegraph/sparql"
 }


### PR DESCRIPTION
I was able to create a Dockerfile based on the new instructions in build.sbt.  Here's a list of things to do to replicate locally:

- install docker based on this: https://docs.docker.com/engine/install/ubuntu/
- run "sbt docker:stage"
- run "sbt docker:publishLocal"
- run "docker run -it cam-kp-api:0.1"

This brought up the server locally.  

I don't know Docker best-practices or if there are any gotchas on deploying to other docker container engine instances, but this is a start.