### PR TITLE
Use key encoder/decoders for IRIs.

### DIFF
--- a/src/main/scala/org/renci/cam/Implicits.scala
+++ b/src/main/scala/org/renci/cam/Implicits.scala
@@ -2,7 +2,7 @@ package org.renci.cam
 
 import com.google.common.base.CaseFormat
 import io.circe.Decoder.Result
-import io.circe.{Decoder, DecodingFailure, Encoder, HCursor}
+import io.circe.{Decoder, DecodingFailure, Encoder, HCursor, KeyDecoder, KeyEncoder}
 import org.apache.commons.lang3.StringUtils
 import org.renci.cam.domain.{BiolinkClass, BiolinkPredicate, BiolinkTerm, IRI}
 
@@ -16,9 +16,20 @@ object Implicits {
 
     override def apply(c: HCursor): Result[IRI] = for {
       value <- c.value.as[String]
-      curie <- value match {
+      iri <- expandCURIEString(value, prefixesMap)
+    } yield iri
+
+  }
+
+  def iriKeyDecoder(prefixesMap: Map[String, String]): KeyDecoder[IRI] = new KeyDecoder[IRI] {
+    override def apply(key: String): Option[IRI] = expandCURIEString(key, prefixesMap).toOption
+  }
+
+  private def expandCURIEString(curieString: String, prefixesMap: Map[String, String]): Either[DecodingFailure, IRI] =
+    for {
+      curie <- curieString match {
         case Curie(p, l) => Right((p, l))
-        case _           => Left(DecodingFailure(s"CURIE is malformed: $value", Nil))
+        case _           => Left(DecodingFailure(s"CURIE is malformed: $curieString", Nil))
       }
       (prefix, local) = curie
       namespace <-
@@ -26,15 +37,30 @@ object Implicits {
         else prefixesMap.get(prefix).toRight(DecodingFailure(s"No prefix expansion found for $prefix:$local", Nil))
     } yield IRI(s"$namespace$local")
 
+  def iriEncoderOut(prefixesMap: Map[String, String]): Encoder[IRI] = Encoder.encodeString.contramap { iri =>
+    compactIRIIfPossible(iri, prefixesMap)
   }
 
-  def iriEncoderOut(prefixesMap: Map[String, String]): Encoder[IRI] = Encoder.encodeString.contramap { iri =>
+  def iriKeyEncoder(prefixesMap: Map[String, String]): KeyEncoder[IRI] = KeyEncoder.encodeKeyString.contramap { iri: IRI =>
+    compactIRIIfPossible(iri, prefixesMap)
+  }
+
+  private def compactIRIIfPossible(iri: IRI, prefixesMap: Map[String, String]): String = {
     val startsWith = prefixesMap.filter { case (_, namespace) => iri.value.startsWith(namespace) }
     if (startsWith.nonEmpty) {
       val (prefix, namespace) = startsWith.maxBy(_._2.length)
       StringUtils.prependIfMissing(iri.value.drop(namespace.length), s"$prefix:")
-    } else iri.value
+    } else {
+      val httpsIRI = toHttps(iri.value)
+      val httpsStartsWith = prefixesMap.filter { case (_, namespace) => httpsIRI.startsWith(namespace) }
+      if (httpsStartsWith.nonEmpty) {
+        val (prefix, namespace) = httpsStartsWith.maxBy(_._2.length)
+        StringUtils.prependIfMissing(httpsIRI.drop(namespace.length), s"$prefix:")
+      } else iri.value
+    }
   }
+
+  private def toHttps(uri: String): String = uri.replaceFirst("http:", "https:")
 
   def iriEncoderIn(prefixesMap: Map[String, String]): Encoder[IRI] = Encoder.encodeString.contramap { iri =>
     val startsWith = prefixesMap.filter { case (prefix, namespace) => iri.value.startsWith(namespace) }

--- a/src/main/scala/org/renci/cam/domain/package.scala
+++ b/src/main/scala/org/renci/cam/domain/package.scala
@@ -101,16 +101,15 @@ package object domain {
                              predicate: Option[BiolinkPredicate],
                              attributes: Option[List[TRAPIAttribute]])
 
-  final case class TRAPIAttribute(name: Option[String], value: String, `type`: IRI,  url: Option[String])
+  final case class TRAPIAttribute(name: Option[String], value: String, `type`: IRI, url: Option[String])
 
-  final case class TRAPIKnowledgeGraph(nodes: Map[String, TRAPINode], edges: Map[String, TRAPIEdge])
+  final case class TRAPIKnowledgeGraph(nodes: Map[IRI, TRAPINode], edges: Map[String, TRAPIEdge])
 
   final case class TRAPINodeBinding(id: IRI)
 
   final case class TRAPIEdgeBinding(id: String, provenance: Option[String])
 
-  final case class TRAPIResult(node_bindings: Map[String, TRAPINodeBinding],
-                               edge_bindings: Map[String, TRAPIEdgeBinding])
+  final case class TRAPIResult(node_bindings: Map[String, TRAPINodeBinding], edge_bindings: Map[String, TRAPIEdgeBinding])
 
   final case class TRAPIMessage(query_graph: Option[TRAPIQueryGraph],
                                 knowledge_graph: Option[TRAPIKnowledgeGraph],

--- a/src/test/scala/org/renci/cam/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/QueryServiceTest.scala
@@ -21,8 +21,8 @@ object QueryServiceTest extends DefaultRunnableSpec {
 
   val listNodeTypes = suite("listNodeTypes")(
     test("testGetNodeTypes") {
-      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("gene")), None)
-      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
+      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("Gene")), None)
+      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
       val e0Edge = TRAPIQueryEdge("n1", "n0", Some(BiolinkPredicate("has_participant")), None)
 
       val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
@@ -42,11 +42,11 @@ object QueryServiceTest extends DefaultRunnableSpec {
           implicit val iriEncoder: Encoder[IRI] = Implicits.iriEncoderIn(biolinkData.prefixes)
           implicit val iriKeyDecoder: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
           implicit val iriKeyEncoder: KeyEncoder[IRI] = Implicits.iriKeyEncoder(biolinkData.prefixes)
-          implicit val biolinkClassEncoder: Encoder[BiolinkClass] = Encoder.encodeString.contramap(blTerm => blTerm.shorthand)
-          implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] = Encoder.encodeString.contramap(blTerm => blTerm.shorthand)
+          implicit val biolinkClassEncoder: Encoder[BiolinkClass] = Encoder.encodeString.contramap(blTerm => blTerm.withBiolinkPrefix)
+          implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] = Encoder.encodeString.contramap(blTerm => blTerm.withBiolinkPrefix)
 
-          val n0Node = TRAPIQueryNode(None /*Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558"))*/, Some(BiolinkClass("gene")), None)
-          val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
+          val n0Node = TRAPIQueryNode(None /*Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558"))*/, Some(BiolinkClass("Gene")), None)
+          val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
           val e0Edge = TRAPIQueryEdge("n1", "n0", Some(BiolinkPredicate("has_participant")), None)
           val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
           val message = TRAPIMessage(Some(queryGraph), None, None)
@@ -64,13 +64,13 @@ object QueryServiceTest extends DefaultRunnableSpec {
         _ = Files.writeString(Paths.get("src/test/resources/local-scala-new.json"), response)
       } yield assert(response)(isNonEmptyString)
       testCase.provideCustomLayer(testLayer)
-    } @@ ignore
+    } //@@ ignore
   )
 
   val testFindGenesEnablingAnyKindOfCatalyticActivity = suite("testFindGenesEnablingAnyKindOfCatalyticActivity")(
     testM("find genes enabling any kind of catalytic activity") {
-      val n0Node = TRAPIQueryNode(None, Some(BiolinkClass("gene_or_gene_product")), None)
-      val n1Node = TRAPIQueryNode(Some(IRI("http://purl.obolibrary.org/obo/GO_0003824")), Some(BiolinkClass("molecular_activity")), None)
+      val n0Node = TRAPIQueryNode(None, Some(BiolinkClass("GeneOrGeneProduct")), None)
+      val n1Node = TRAPIQueryNode(Some(IRI("http://purl.obolibrary.org/obo/GO_0003824")), Some(BiolinkClass("MolecularActivity")), None)
       val e0Edge = TRAPIQueryEdge("n1", "n0", Some(BiolinkPredicate("enabled_by")), None)
       val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
       val message = TRAPIMessage(Some(queryGraph), None, None)
@@ -84,8 +84,8 @@ object QueryServiceTest extends DefaultRunnableSpec {
           implicit val iriEncoder: Encoder[IRI] = Implicits.iriEncoderIn(biolinkData.prefixes)
           implicit val iriKeyDecoder: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
           implicit val iriKeyEncoder: KeyEncoder[IRI] = Implicits.iriKeyEncoder(biolinkData.prefixes)
-          implicit val biolinkClassEncoder: Encoder[BiolinkClass] = Encoder.encodeString.contramap(blTerm => blTerm.shorthand)
-          implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] = Encoder.encodeString.contramap(blTerm => blTerm.shorthand)
+          implicit val biolinkClassEncoder: Encoder[BiolinkClass] = Encoder.encodeString.contramap(blTerm => blTerm.withBiolinkPrefix)
+          implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] = Encoder.encodeString.contramap(blTerm => blTerm.withBiolinkPrefix)
           requestBody.asJson.deepDropNullValues.noSpaces
         }
         _ = println("encoded: " + encoded)
@@ -104,10 +104,10 @@ object QueryServiceTest extends DefaultRunnableSpec {
 
   val testGene2Process2Process2Gene = suite("testGene2Process2Process2Gene")(
     testM("test gene to process to process to gene") {
-      val n0Node = TRAPIQueryNode(Some(IRI("http://identifiers.org/uniprot/P30530")), Some(BiolinkClass("gene")), None)
-      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
-      val n2Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
-      val n3Node = TRAPIQueryNode(None, Some(BiolinkClass("gene")), None)
+      val n0Node = TRAPIQueryNode(Some(IRI("http://identifiers.org/uniprot/P30530")), Some(BiolinkClass("Gene")), None)
+      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
+      val n2Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
+      val n3Node = TRAPIQueryNode(None, Some(BiolinkClass("Gene")), None)
       val e0Edge = TRAPIQueryEdge("n1", "n0", None, None)
       val e1Edge = TRAPIQueryEdge("n1", "n2", None /*Some(CURIEorIRI(None, "enabled_by"))*/, None)
       val e2Edge = TRAPIQueryEdge("n2", "n3", None, None)
@@ -146,8 +146,8 @@ object QueryServiceTest extends DefaultRunnableSpec {
         TRAPIQueryNode(Some(IRI("http://purl.obolibrary.org/obo/GO_0004252")), Some(BiolinkClass("biological_process_or_activity")), None)
       val n1Node =
         TRAPIQueryNode(Some(IRI("http://purl.obolibrary.org/obo/GO_0003810")), Some(BiolinkClass("biological_process_or_activity")), None)
-      val n2Node = TRAPIQueryNode(None, Some(BiolinkClass("gene_or_gene_product")), None)
-      val e0Edge = TRAPIQueryEdge("n0", "n1", Some(BiolinkPredicate("positively_regulates")), None)
+      val n2Node = TRAPIQueryNode(None, Some(BiolinkClass("GeneOrGeneProduct")), None)
+      val e0Edge = TRAPIQueryEdge("n0", "n1", Some(BiolinkPredicate("PositivelyRegulates")), None)
       val e1Edge = TRAPIQueryEdge("n1", "n2", Some(BiolinkPredicate("enabled_by")), None)
       val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node, "n2" -> n2Node), Map("e0" -> e0Edge, "e1" -> e1Edge))
       val message = TRAPIMessage(Some(queryGraph), None, None)

--- a/src/test/scala/org/renci/cam/QueryServiceTest.scala
+++ b/src/test/scala/org/renci/cam/QueryServiceTest.scala
@@ -64,7 +64,7 @@ object QueryServiceTest extends DefaultRunnableSpec {
         _ = Files.writeString(Paths.get("src/test/resources/local-scala-new.json"), response)
       } yield assert(response)(isNonEmptyString)
       testCase.provideCustomLayer(testLayer)
-    } //@@ ignore
+    } @@ ignore
   )
 
   val testFindGenesEnablingAnyKindOfCatalyticActivity = suite("testFindGenesEnablingAnyKindOfCatalyticActivity")(

--- a/src/test/scala/org/renci/cam/SerializationTest.scala
+++ b/src/test/scala/org/renci/cam/SerializationTest.scala
@@ -48,8 +48,8 @@ object SerializationTest extends DefaultRunnableSpec {
         """{"message":{"query_graph":{"nodes":["n0":{"id":"NCBIGene:558", "category":"biolink:Gene"}, "n1":{"category":"biolink:BiologicalProcess"}],"edges":[{"id":"e0","subject":"n0","object":"n1","predicate":"biolink:has_participant"}]}}}"""
       println("expected: " + expected)
 
-      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("gene")), None)
-      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
+      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("Gene")), None)
+      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
       val e0Edge = TRAPIQueryEdge("n0", "n1", Some(BiolinkPredicate("has_participant")), None)
 
       val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
@@ -99,8 +99,8 @@ object SerializationTest extends DefaultRunnableSpec {
       val expected =
         """{"message":{"query_graph":{"nodes":[{"id":"n0","type":"https://w3id.org/biolink/vocab/Gene","curie":"http://www.ncbi.nlm.nih.gov/gene/558"},{"id":"n1","type":"https://w3id.org/biolink/vocab/BiologicalProcess"}],"edges":[{"id":"e0","source_id":"n0","target_id":"n1","type":"https://w3id.org/biolink/vocab/has_participant"}]}}}"""
 
-      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("gene")), None)
-      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
+      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("Gene")), None)
+      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
       val e0Edge = TRAPIQueryEdge("n0", "n1", Some(BiolinkPredicate("has_participant")), None)
 
       val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))
@@ -129,8 +129,8 @@ object SerializationTest extends DefaultRunnableSpec {
   val testTRAPIQueryRequestBodyDecoding2 = suite("testTRAPIQueryRequestBodyDecoding2")(
     testM("decoding") {
 
-      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("gene")), None)
-      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("biological_process")), None)
+      val n0Node = TRAPIQueryNode(Some(IRI("http://www.ncbi.nlm.nih.gov/gene/558")), Some(BiolinkClass("Gene")), None)
+      val n1Node = TRAPIQueryNode(None, Some(BiolinkClass("BiologicalProcess")), None)
       val e0Edge = TRAPIQueryEdge("n0", "n1", Some(BiolinkPredicate("has_participant")), None)
 
       val queryGraph = TRAPIQueryGraph(Map("n0" -> n0Node, "n1" -> n1Node), Map("e0" -> e0Edge))

--- a/src/test/scala/org/renci/cam/SerializationTest.scala
+++ b/src/test/scala/org/renci/cam/SerializationTest.scala
@@ -4,10 +4,11 @@ import java.io.ByteArrayOutputStream
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
+
 import io.circe.generic.auto._
 import io.circe.parser._
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder, HCursor, Json, KeyEncoder}
+import io.circe.{Decoder, Encoder, HCursor, Json, KeyDecoder, KeyEncoder}
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
 import org.apache.jena.query.{ResultSetFactory, ResultSetFormatter}
@@ -41,7 +42,6 @@ object SerializationTest extends DefaultRunnableSpec {
     } /*@@ ignore*/
   )
 
-
   val testTRAPIQueryRequestBodyEncodingOut = suite("testTRAPIQueryRequestBodyEncodingOut")(
     testM("encoding upon departure") {
       val expected =
@@ -58,6 +58,8 @@ object SerializationTest extends DefaultRunnableSpec {
       val testCase = for {
         biolinkData <- Biolink.biolinkData
       } yield {
+        implicit val iriKeyDecoder: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+        implicit val iriKeyEncoder: KeyEncoder[IRI] = Implicits.iriKeyEncoder(biolinkData.prefixes)
 //        implicit val iriEncoder: Encoder[IRI] = Implicits.iriEncoderOut(biolinkData.prefixes)
 //        implicit val biolinkClassEncoder: Encoder[BiolinkClass] = Encoder.encodeString.contramap(blTerm => blTerm.shorthand)
 //        implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] = Encoder.encodeString.contramap(blTerm => blTerm.shorthand)
@@ -109,6 +111,8 @@ object SerializationTest extends DefaultRunnableSpec {
       } yield {
         implicit val iriDecoder: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
         implicit val iriEncoder: Encoder[IRI] = Implicits.iriEncoderIn(biolinkData.prefixes)
+        implicit val iriKeyDecoder: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+        implicit val iriKeyEncoder: KeyEncoder[IRI] = Implicits.iriKeyEncoder(biolinkData.prefixes)
         implicit val biolinkClassEncoder: Encoder[BiolinkClass] = Encoder.encodeString.contramap(blTerm => blTerm.iri.value)
         implicit val biolinkPredicateEncoder: Encoder[BiolinkPredicate] = Encoder.encodeString.contramap(blTerm => blTerm.iri.value)
         val encoded = requestBody.asJson.deepDropNullValues.noSpaces
@@ -136,6 +140,8 @@ object SerializationTest extends DefaultRunnableSpec {
         biolinkData <- Biolink.biolinkData
       } yield {
         implicit val iriDecoder: Decoder[IRI] = Implicits.iriDecoder(biolinkData.prefixes)
+        implicit val iriKeyDecoder: KeyDecoder[IRI] = Implicits.iriKeyDecoder(biolinkData.prefixes)
+        implicit val iriKeyEncoder: KeyEncoder[IRI] = Implicits.iriKeyEncoder(biolinkData.prefixes)
 //        implicit val iriEncoder: Encoder[IRI] = IRI.makeEncoderIn(biolinkData.prefixesMap)
         val encoded = requestBody.asJson.deepDropNullValues.noSpaces
         //        println("encoded: " + encoded)


### PR DESCRIPTION
Added KeyDecoder/KeyEncoder for IRIs, so that we don't convert to strings before the response is rendered.