### PR TITLE
Use FILTER IN instead of VALUES for relation lists

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,7 @@ coverageExcludedPackages := "<empty>;org\\.renci\\.cam\\.domain\\..*;org\\.renci
 
 val zioVersion = "1.0.9"
 val zioConfigVersion = "1.0.0-RC29-1"
+val zioCacheVersion = "0.1.0"
 val tapirVersion = "0.16.16"
 val http4sVersion = "0.21.25"
 val circeVersion = "0.14.1"
@@ -42,6 +43,7 @@ libraryDependencies ++= {
     "dev.zio"                     %% "zio-config"                     % zioConfigVersion,
     "dev.zio"                     %% "zio-config-magnolia"            % zioConfigVersion,
     "dev.zio"                     %% "zio-config-typesafe"            % zioConfigVersion,
+    "dev.zio"                     %% "zio-cache"                      % zioCacheVersion,
     "com.softwaremill.sttp.tapir" %% "tapir-core"                     % tapirVersion,
     "com.softwaremill.sttp.tapir" %% "tapir-zio"                      % tapirVersion,
     "com.softwaremill.sttp.tapir" %% "tapir-zio-http4s-server"        % tapirVersion,

--- a/src/main/scala/org/renci/cam/Util.scala
+++ b/src/main/scala/org/renci/cam/Util.scala
@@ -8,6 +8,15 @@ object Util {
 
     def asValues: QueryText = self.map(item => sparql" $item ").fold(sparql"")(_ + _)
 
+    def asSPARQLList: QueryText =
+      interpolate(sparql", ", self.to(List).map(item => sparql"$item")).fold(sparql"")(_ + _)
+
+  }
+
+  def interpolate[T](elem: T, list: List[T]): List[T] = list match {
+    case Nil             => Nil
+    case last @ _ :: Nil => last
+    case x :: xs         => x :: elem :: interpolate(elem, xs)
   }
 
 }


### PR DESCRIPTION
Seems to avoid performance traps. Also add SPARQL cache, used for only the initial relation lookup at the moment.