### PR TITLE
Fix query stalling

### DIFF
--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 
 object QueryService extends LazyLogging {
 
-  val INNER_LIMIT = 1000
+  val INNER_LIMIT_MULTIPLIER = 10000
 
   val ProvWasDerivedFrom: IRI = IRI("http://www.w3.org/ns/prov#wasDerivedFrom")
 
@@ -496,7 +496,7 @@ object QueryService extends LazyLogging {
               SELECT $nodeProjections ?g
               WHERE {
                 $edgePatterns
-              } LIMIT ${INNER_LIMIT}
+              } LIMIT ${if (limit == 0) INNER_LIMIT_MULTIPLIER else INNER_LIMIT_MULTIPLIER * limit}
             }
             $BigDataQueryHintPrior $BigDataQueryHintRunFirst true .
           }

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -485,6 +485,7 @@ object QueryService extends LazyLogging {
     val nodesToDirectTypes = getNodesToDirectTypes(queryGraph.nodes)
     val edgePatterns = queryEdgeSparql.fold(sparql"")(_ + _)
     val limitSparql = if (limit > 0) sparql" LIMIT $limit" else sparql""
+    val innerLimit = if (limit == 0) INNER_LIMIT_MULTIPLIER else (INNER_LIMIT_MULTIPLIER * limit)
     val queryString =
       sparql"""SELECT DISTINCT $typeProjections
                (GROUP_CONCAT(DISTINCT ?g; SEPARATOR='|') AS ?graphs)
@@ -496,7 +497,7 @@ object QueryService extends LazyLogging {
               SELECT $nodeProjections ?g
               WHERE {
                 $edgePatterns
-              } LIMIT ${if (limit == 0) INNER_LIMIT_MULTIPLIER else INNER_LIMIT_MULTIPLIER * limit}
+              } LIMIT ${innerLimit}
             }
             $BigDataQueryHintPrior $BigDataQueryHintRunFirst true .
           }

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -21,6 +21,8 @@ import scala.jdk.CollectionConverters._
 
 object QueryService extends LazyLogging {
 
+  val INNER_LIMIT = 1000
+
   val ProvWasDerivedFrom: IRI = IRI("http://www.w3.org/ns/prov#wasDerivedFrom")
 
   val RDFSSubClassOf: IRI = IRI("http://www.w3.org/2000/01/rdf-schema#subClassOf")
@@ -494,7 +496,7 @@ object QueryService extends LazyLogging {
               SELECT $nodeProjections ?g
               WHERE {
                 $edgePatterns
-              }
+              } LIMIT ${INNER_LIMIT}
             }
             $BigDataQueryHintPrior $BigDataQueryHintRunFirst true .
           }

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 
 object QueryService extends LazyLogging {
 
-  val INNER_LIMIT_MULTIPLIER = 10000
+  val INNER_LIMIT_MULTIPLIER = 1000
 
   val ProvWasDerivedFrom: IRI = IRI("http://www.w3.org/ns/prov#wasDerivedFrom")
 

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -6,13 +6,13 @@ import io.circe.syntax._
 import org.apache.jena.query.QuerySolution
 import org.apache.jena.rdf.model.Resource
 import org.phenoscape.sparql.SPARQLInterpolation._
-import org.renci.cam.Biolink.{biolinkData, BiolinkData}
+import org.renci.cam.Biolink.{BiolinkData, biolinkData}
 import org.renci.cam.HttpClient.HttpClient
 import org.renci.cam.SPARQLQueryExecutor.SPARQLCache
 import org.renci.cam.Util.IterableSPARQLOps
 import org.renci.cam.domain.{TRAPIAttribute, _}
-import zio.config.{getConfig, ZConfig}
-import zio.{config => _, Has, RIO, Task, UIO, ZIO}
+import zio.config.{ZConfig, getConfig}
+import zio.{Has, RIO, Task, UIO, ZIO, config => _}
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
@@ -569,7 +569,6 @@ object QueryService extends LazyLogging {
   def getProjections(queryGraph: TRAPIQueryGraph, typesInsteadOfNodes: Boolean = false): QueryText = {
     val projectionVariableNames =
       queryGraph.edges.keys ++
-        queryGraph.nodes.keys.map(queryNodeID => s"${queryNodeID}_class") ++
         (if (typesInsteadOfNodes) queryGraph.nodes.keys.map(queryNodeID => s"${queryNodeID}_type")
          else queryGraph.edges.flatMap(e => List(e._2.subject, e._2.`object`)))
     projectionVariableNames.map(Var(_)).map(v => sparql" $v ").fold(sparql"")(_ + _)

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -21,7 +21,7 @@ import scala.jdk.CollectionConverters._
 
 object QueryService extends LazyLogging {
 
-  val INNER_LIMIT_MULTIPLIER = 1000
+  val INNER_LIMIT_MULTIPLIER = 100
 
   val ProvWasDerivedFrom: IRI = IRI("http://www.w3.org/ns/prov#wasDerivedFrom")
 
@@ -485,7 +485,8 @@ object QueryService extends LazyLogging {
     val nodesToDirectTypes = getNodesToDirectTypes(queryGraph.nodes)
     val edgePatterns = queryEdgeSparql.fold(sparql"")(_ + _)
     val limitSparql = if (limit > 0) sparql" LIMIT $limit" else sparql""
-    val innerLimit = if (limit == 0) INNER_LIMIT_MULTIPLIER else (INNER_LIMIT_MULTIPLIER * limit)
+    val innerLimit = INNER_LIMIT_MULTIPLIER * limit
+    val innerLimitSparql = if (limit > 0) sparql" LIMIT $innerLimit" else sparql""
     val queryString =
       sparql"""SELECT DISTINCT $typeProjections
                (GROUP_CONCAT(DISTINCT ?g; SEPARATOR='|') AS ?graphs)
@@ -497,7 +498,7 @@ object QueryService extends LazyLogging {
               SELECT $nodeProjections ?g
               WHERE {
                 $edgePatterns
-              } LIMIT ${innerLimit}
+              } ${innerLimitSparql}
             }
             $BigDataQueryHintPrior $BigDataQueryHintRunFirst true .
           }


### PR DESCRIPTION
This PR attempts to fix the query stalling we've noticed (#613).

- One quick-and-dirty fix is to set a high limit for the inner loop -- we're currently using a multiplier (100 times the outer limit), but we should improve the SPARQL query so we don't need it any more.
- Removes `?*_class` from the inner SELECT and the GROUP BY as per https://github.com/ExposuresProvider/cam-kp-api/issues/613#issuecomment-1410959717