### PR TITLE
Update knowledge sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "org.renci"
 
 name := "cam-kp-api"
 
-version := "0.3-pre4"
+version := "0.3"
 
 licenses := Seq("MIT license" -> url("https://opensource.org/licenses/MIT"))
 

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,5 +1,5 @@
 {
-  version = "0.3-pre4"
+  version = "0.3"
   host = 0.0.0.0
   port = 8080
   port = ${?PORT}

--- a/src/main/scala/org/renci/cam/QueryService.scala
+++ b/src/main/scala/org/renci/cam/QueryService.scala
@@ -6,14 +6,14 @@ import io.circe.syntax._
 import org.apache.jena.query.QuerySolution
 import org.apache.jena.rdf.model.Resource
 import org.phenoscape.sparql.SPARQLInterpolation._
-import org.renci.cam.Biolink.{biolinkData, BiolinkData}
+import org.renci.cam.Biolink.{BiolinkData, biolinkData}
 import org.renci.cam.HttpClient.HttpClient
 import org.renci.cam.SPARQLQueryExecutor.SPARQLCache
 import org.renci.cam.Util.IterableSPARQLOps
 import org.renci.cam.domain.PredicateMappings.{getBiolinkQualifiedPredicates, mapQueryEdgePredicates}
 import org.renci.cam.domain._
-import zio.config.{getConfig, ZConfig}
-import zio.{config => _, Has, RIO, Task, UIO, ZIO}
+import zio.config.{ZConfig, getConfig}
+import zio.{Has, RIO, Task, UIO, ZIO, config => _}
 
 import java.math.BigInteger
 import java.nio.charset.StandardCharsets
@@ -199,7 +199,7 @@ object QueryService extends LazyLogging {
       appConfig <- getConfig[AppConfig]
 
       // Generate the attributes we will need to produce the edge output.
-      originalKS <- ZIO
+      primaryKS <- ZIO
         .fromOption(biolinkData.predicates.find(p => p.shorthand == "primary_knowledge_source"))
         .orElseFail(new Exception("could not get biolink:primary_knowledge_source"))
       aggregatorKS <- ZIO
@@ -237,7 +237,7 @@ object QueryService extends LazyLogging {
             }
             originalKSAttributes = originalKnowledgeSources.map { case (derivedFrom, inforesKS) =>
               TRAPIAttribute(Some("infores:cam-kp"),
-                             originalKS.iri,
+                             primaryKS.iri,
                              None,
                              List(inforesKS),
                              Some(infoResBiolinkClass.iri),


### PR DESCRIPTION
Since every Translator KP is expected to return a primary knowledge source, this PR changes the current original_knowledge_source with the new field primary_knowledge_source. We will eventually need to do a better job of figuring out exactly where non-CAM KPs come from (see e.g. #485, #494), but this should be a mostly-correct quick-and-dirty fix for now.

Closes  #628.

Should be merged after PR #620.